### PR TITLE
Fix typo in Coding Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ There are many ways to contribute, including:
     - 2. Write clear, readable, and well-commented code.
     - 3. Code must work and be tested with `./build.sh run`.
     - 4. ONLY .ld, .S, .h, .c, .md (git docs only), and, Containerfile is allowed.
-    - 5. Featrues must be mostly working before a PR.
+    - 5. Features must be mostly working before a PR.
 
 ## Reporting Issues
 


### PR DESCRIPTION
Silly pull, but I was looking through your OS and couldn't help notice a typo in CONTRIBUTING.md. 